### PR TITLE
Make ctrl+c exit the default make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SRC:=$(PWD)/src
 
 dev:
 	@mkdir -pv $(SRC)
-	@docker run -v $(SRC):/usr/app/src:ro -p 8080:8080 $(TAG) dev
+	@docker run -ti -v $(SRC):/usr/app/src:ro -p 8080:8080 $(TAG) dev
 
 docker:
 	@docker build --tag $(TAG) .


### PR DESCRIPTION
This makes the dev shell run in interactive mode, with the following benefits:
- ctrl+c exits cleanly
- get nice output with colors and all